### PR TITLE
Standardize portfolio spacing

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -35,6 +35,15 @@ div[data-testid="stToolbar"] {
 [data-testid="stAppViewContainer"] .main .block-container > [data-testid="stVerticalBlock"] {
     gap: 0 !important;
 }
+[data-testid="stMainBlockContainer"],
+.stMainBlockContainer,
+.block-container {
+    padding-top: 0 !important;
+    margin-top: 0 !important;
+}
+[data-testid="stMainBlockContainer"] > [data-testid="stVerticalBlock"] {
+    gap: 0 !important;
+}
 div[data-testid="stElementContainer"]:has(.navbar-container) {
     position: sticky;
     top: 0;
@@ -669,7 +678,7 @@ st.markdown(
         align-items: center;
         justify-content: center;
         text-align: center;
-        margin: 0 0 24px;
+        margin: 16px 0;
         box-shadow: 0 6px 30px 0 rgba(60,100,180,0.11), 0 1.5px 8px 0 rgba(60,60,90,0.08);
         transition: transform .35s cubic-bezier(.33,1.6,.66,1), box-shadow .33s;
         position: relative;
@@ -703,7 +712,7 @@ st.markdown("""
   background: linear-gradient(135deg, #253451 0%, #324665 100%);
   border-radius: 24px;
   box-shadow: 0 6px 26px rgba(20,30,55,0.18), 0 2px 14px rgba(44,62,80,0.08);
-  margin-bottom: 32px;
+  margin-bottom: 16px;
   min-height: 330px;
   position: relative;
   overflow: hidden;

--- a/streamlit_app_single_pane.py
+++ b/streamlit_app_single_pane.py
@@ -22,6 +22,15 @@ div[data-testid="stToolbar"] {
 [data-testid="stAppViewContainer"] .main .block-container > [data-testid="stVerticalBlock"] {
     gap: 0 !important;
 }
+[data-testid="stMainBlockContainer"],
+.stMainBlockContainer,
+.block-container {
+    padding-top: 0 !important;
+    margin-top: 0 !important;
+}
+[data-testid="stMainBlockContainer"] > [data-testid="stVerticalBlock"] {
+    gap: 0 !important;
+}
 div[data-testid="stElementContainer"]:has(.navbar-container) {
     position: sticky;
     top: 0;
@@ -649,7 +658,7 @@ st.markdown(
         align-items: center;
         justify-content: center;
         text-align: center;
-        margin: 0 0 24px;
+        margin: 16px 0;
         box-shadow: 0 6px 30px 0 rgba(60,100,180,0.11), 0 1.5px 8px 0 rgba(60,60,90,0.08);
         transition: transform .35s cubic-bezier(.33,1.6,.66,1), box-shadow .33s;
         position: relative;
@@ -683,7 +692,7 @@ st.markdown("""
   background: linear-gradient(135deg, #253451 0%, #324665 100%);
   border-radius: 24px;
   box-shadow: 0 6px 26px rgba(20,30,55,0.18), 0 2px 14px rgba(44,62,80,0.08);
-  margin-bottom: 32px;
+  margin-bottom: 16px;
   min-height: 330px;
   position: relative;
   overflow: hidden;


### PR DESCRIPTION
## Uniform 16px spacing

- targets Streamlit’s current `stMainBlockContainer` to remove the default top padding above the navigation
- removes implicit top-level Streamlit element gaps
- applies an explicit 16px gap between the menu and welcome card
- applies the same 16px gap between the welcome card and About section
- reduces the About card’s bottom spacing to the same 16px rhythm
- updates both Streamlit entry files

## Validation

- both Python entry files compile successfully
- patch and whitespace validation pass