### PR TITLE
Apply equal spacing between portfolio sections

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -19,6 +19,7 @@ st.markdown("""
 <style>
 :root {
     --navbar-total-height: 0px;
+    --section-gap: 16px;
 }
 body {
     margin: 0 !important;
@@ -43,6 +44,20 @@ div[data-testid="stToolbar"] {
 }
 [data-testid="stMainBlockContainer"] > [data-testid="stVerticalBlock"] {
     gap: 0 !important;
+}
+[data-testid="stMainBlockContainer"] > [data-testid="stVerticalBlock"] > div[data-testid="stElementContainer"]:has(.hero-card),
+[data-testid="stMainBlockContainer"] > [data-testid="stVerticalBlock"] > div[data-testid="stElementContainer"]:has(.card),
+[data-testid="stMainBlockContainer"] > [data-testid="stVerticalBlock"] > div[data-testid="stElementContainer"]:has(.skills-section) {
+    padding-bottom: var(--section-gap) !important;
+}
+[data-testid="stMainBlockContainer"] > [data-testid="stVerticalBlock"] > div[data-testid="stElementContainer"]:has(.hero-card) {
+    padding-top: var(--section-gap) !important;
+}
+.hero-card,
+.card,
+.skills-section {
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
 }
 div[data-testid="stElementContainer"]:has(.navbar-container) {
     position: sticky;

--- a/streamlit_app_single_pane.py
+++ b/streamlit_app_single_pane.py
@@ -7,6 +7,9 @@ st.set_page_config(page_title="Venkatesh Portfolio", layout="wide")
 # ---- FREEZED (FIXED) NAVIGATION BAR ----
 st.markdown("""
 <style>
+:root {
+    --section-gap: 16px;
+}
 body {
     margin: 0 !important;
     padding: 0 !important;
@@ -30,6 +33,20 @@ div[data-testid="stToolbar"] {
 }
 [data-testid="stMainBlockContainer"] > [data-testid="stVerticalBlock"] {
     gap: 0 !important;
+}
+[data-testid="stMainBlockContainer"] > [data-testid="stVerticalBlock"] > div[data-testid="stElementContainer"]:has(.hero-card),
+[data-testid="stMainBlockContainer"] > [data-testid="stVerticalBlock"] > div[data-testid="stElementContainer"]:has(.card),
+[data-testid="stMainBlockContainer"] > [data-testid="stVerticalBlock"] > div[data-testid="stElementContainer"]:has(.skills-section) {
+    padding-bottom: var(--section-gap) !important;
+}
+[data-testid="stMainBlockContainer"] > [data-testid="stVerticalBlock"] > div[data-testid="stElementContainer"]:has(.hero-card) {
+    padding-top: var(--section-gap) !important;
+}
+.hero-card,
+.card,
+.skills-section {
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
 }
 div[data-testid="stElementContainer"]:has(.navbar-container) {
     position: sticky;


### PR DESCRIPTION
## What changed

- introduced one shared 16px spacing value for the portfolio layout
- applies that spacing to Streamlit’s outer element containers so margins no longer collapse
- gives the first About card the same 16px gap below the navigation
- applies equal gaps between About, Education, Experience, Certifications, Recognitions, Projects, Skills, and other major cards
- resets conflicting inner-card margins to prevent double spacing
- updates both Streamlit entry files

## Root cause

The inner banner margins were collapsing inside Streamlit element containers while the top-level Streamlit gap was set to zero. This caused adjacent banners to touch.

## Validation

- both Python entry files compile successfully
- whitespace validation passes
- branch comparison confirms only the two Streamlit entry files changed