### PR TITLE
Make portfolio section gaps reliably visible

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -45,14 +45,6 @@ div[data-testid="stToolbar"] {
 [data-testid="stMainBlockContainer"] > [data-testid="stVerticalBlock"] {
     gap: 0 !important;
 }
-[data-testid="stMainBlockContainer"] > [data-testid="stVerticalBlock"] > div[data-testid="stElementContainer"]:has(.hero-card),
-[data-testid="stMainBlockContainer"] > [data-testid="stVerticalBlock"] > div[data-testid="stElementContainer"]:has(.card),
-[data-testid="stMainBlockContainer"] > [data-testid="stVerticalBlock"] > div[data-testid="stElementContainer"]:has(.skills-section) {
-    padding-bottom: var(--section-gap) !important;
-}
-[data-testid="stMainBlockContainer"] > [data-testid="stVerticalBlock"] > div[data-testid="stElementContainer"]:has(.hero-card) {
-    padding-top: var(--section-gap) !important;
-}
 .hero-card,
 .card,
 .skills-section {
@@ -532,6 +524,8 @@ st.markdown("""
   margin-bottom: 2px;
 }
 .section-anchor {
+  display: block;
+  height: var(--section-gap);
   scroll-margin-top: 160px; /* or 100px, depending on your navbar height */
 }
 .skill-chip {
@@ -1209,7 +1203,7 @@ projects_html += '</div></div>'
 st.markdown(projects_html, unsafe_allow_html=True)
 
 
-st.markdown('<a name="skills"></a>', unsafe_allow_html=True)
+st.markdown('<a name="skills" class="section-anchor"></a>', unsafe_allow_html=True)
 
 st.markdown("""
 <style>

--- a/streamlit_app_single_pane.py
+++ b/streamlit_app_single_pane.py
@@ -34,14 +34,6 @@ div[data-testid="stToolbar"] {
 [data-testid="stMainBlockContainer"] > [data-testid="stVerticalBlock"] {
     gap: 0 !important;
 }
-[data-testid="stMainBlockContainer"] > [data-testid="stVerticalBlock"] > div[data-testid="stElementContainer"]:has(.hero-card),
-[data-testid="stMainBlockContainer"] > [data-testid="stVerticalBlock"] > div[data-testid="stElementContainer"]:has(.card),
-[data-testid="stMainBlockContainer"] > [data-testid="stVerticalBlock"] > div[data-testid="stElementContainer"]:has(.skills-section) {
-    padding-bottom: var(--section-gap) !important;
-}
-[data-testid="stMainBlockContainer"] > [data-testid="stVerticalBlock"] > div[data-testid="stElementContainer"]:has(.hero-card) {
-    padding-top: var(--section-gap) !important;
-}
 .hero-card,
 .card,
 .skills-section {
@@ -515,6 +507,8 @@ st.markdown("""
   margin-bottom: 2px;
 }
 .section-anchor {
+  display: block;
+  height: var(--section-gap);
   scroll-margin-top: 160px; /* or 100px, depending on your navbar height */
 }
 .skill-chip {
@@ -1192,7 +1186,7 @@ projects_html += '</div></div>'
 st.markdown(projects_html, unsafe_allow_html=True)
 
 
-st.markdown('<a name="skills"></a>', unsafe_allow_html=True)
+st.markdown('<a name="skills" class="section-anchor"></a>', unsafe_allow_html=True)
 
 st.markdown("""
 <style>


### PR DESCRIPTION
## What changed

- replaces the non-matching Streamlit wrapper selector with explicit section-anchor spacing
- gives every main navigation section a real 16px spacer before its banner
- adds the same section-anchor class to Skills
- keeps inner card margins reset so the gap remains exactly 16px
- updates both Streamlit entry files

## Root cause

Streamlit inserts additional wrapper elements around rendered Markdown. The previous direct-child selector did not match those wrappers, so its padding rule never appeared in the live application.

## Validation

- both Python entry files compile successfully
- whitespace validation passes
- all seven section anchors use the shared 16px spacing value
- branch comparison confirms only the two Streamlit entry files changed