### PR TITLE
Increase portfolio section spacing

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -19,7 +19,7 @@ st.markdown("""
 <style>
 :root {
     --navbar-total-height: 0px;
-    --section-gap: 16px;
+    --section-gap: 32px;
 }
 body {
     margin: 0 !important;

--- a/streamlit_app_single_pane.py
+++ b/streamlit_app_single_pane.py
@@ -8,7 +8,7 @@ st.set_page_config(page_title="Venkatesh Portfolio", layout="wide")
 st.markdown("""
 <style>
 :root {
-    --section-gap: 16px;
+    --section-gap: 32px;
 }
 body {
     margin: 0 !important;


### PR DESCRIPTION
## What changed

- increases the shared section gap from 16px to 32px
- applies the larger gap uniformly across all main portfolio banners
- updates both Streamlit entry files

## Impact

The patterned background separation between adjacent sections will now be clearly visible without creating the oversized empty areas seen in earlier versions.

## Validation

- both Python entry files compile successfully
- whitespace validation passes
- branch comparison confirms this is a two-line CSS value change