### PR TITLE
Fix horizontal portfolio carousel initialization

### DIFF
--- a/portfolio_carousel.py
+++ b/portfolio_carousel.py
@@ -225,6 +225,15 @@ def render_section_carousel():
     return element?.closest('div[data-testid="stElementContainer"]') || null;
   }
 
+  function hideSource(node) {
+    if (!node || node.getAttribute(sourceAttribute) === "true") {
+      return;
+    }
+    node.dataset.portfolioCarouselDisplay = node.style.display || "";
+    node.setAttribute(sourceAttribute, "true");
+    node.style.display = "none";
+  }
+
   function buildCarousel(attempt = 0) {
     restoreSources();
     parentDocument.getElementById(shellId)?.remove();
@@ -232,24 +241,30 @@ def render_section_carousel():
     const anchors = sectionIds.map((id) =>
       parentDocument.querySelector(`a.section-anchor[name="${id}"]`)
     );
-    const endMarker = parentDocument.querySelector(".portfolio-carousel-end-marker");
+    const sectionRoots = sectionIds.map((id) =>
+      parentDocument.querySelector(`[data-portfolio-section="${id}"]`)
+    );
 
-    if (anchors.some((anchor) => !anchor) || !endMarker) {
+    if (
+      anchors.some((anchor) => !anchor) ||
+      sectionRoots.some((sectionRoot) => !sectionRoot)
+    ) {
       if (attempt < 80) {
         window.setTimeout(() => buildCarousel(attempt + 1), 75);
       }
       return;
     }
 
-    const starts = anchors.map(closestElementContainer);
-    const endContainer = closestElementContainer(endMarker);
-    const sectionParent = starts[0]?.parentElement;
+    const anchorContainers = anchors.map(closestElementContainer);
+    const sourceContainers = sectionRoots.map(closestElementContainer);
+    const firstSource = sourceContainers[0];
+    const sectionParent = firstSource?.parentElement;
 
     if (
       !sectionParent ||
-      !endContainer ||
-      starts.some((start) => !start || start.parentElement !== sectionParent) ||
-      endContainer.parentElement !== sectionParent
+      anchorContainers.some((anchorContainer) => !anchorContainer) ||
+      sourceContainers.some((sourceContainer) => !sourceContainer) ||
+      new Set(sourceContainers).size !== sectionIds.length
     ) {
       if (attempt < 80) {
         window.setTimeout(() => buildCarousel(attempt + 1), 75);
@@ -303,22 +318,15 @@ def render_section_carousel():
     const slides = [];
     const dotButtons = [];
 
-    starts.forEach((start, index) => {
-      const stop = index + 1 < starts.length ? starts[index + 1] : endContainer;
+    sourceContainers.forEach((sourceContainer, index) => {
       const slide = parentDocument.createElement("section");
       slide.className = "portfolio-carousel-slide";
       slide.dataset.sectionId = sectionIds[index];
       slide.setAttribute("aria-label", sectionLabels[index]);
 
-      let node = start;
-      while (node && node !== stop) {
-        const clone = node.cloneNode(true);
-        slide.appendChild(clone);
-        node.dataset.portfolioCarouselDisplay = node.style.display || "";
-        node.setAttribute(sourceAttribute, "true");
-        node.style.display = "none";
-        node = node.nextSibling;
-      }
+      slide.appendChild(sourceContainer.cloneNode(true));
+      hideSource(sourceContainer);
+      hideSource(anchorContainers[index]);
 
       const dot = parentDocument.createElement("button");
       dot.className = "portfolio-carousel-dot";
@@ -333,7 +341,7 @@ def render_section_carousel():
     });
 
     shell.append(controls, track, dots);
-    sectionParent.insertBefore(shell, starts[0]);
+    sectionParent.insertBefore(shell, firstSource);
 
     let activeIndex = 0;
     let scrollTimer;

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -880,7 +880,7 @@ st.markdown("""
 }
 </style>
 
-<div class="hero-card">
+<div class="hero-card" data-portfolio-section="about">
   <div class="hero-left">
     <div class="hero-pic-glow">
       <img src="https://raw.githubusercontent.com/venkateshsoundar/venkatesh_portfolio/main/Venkatesh_Profile_2026.jpg" alt="Venkatesh Soundararajan"/>
@@ -924,7 +924,7 @@ st.markdown('<a name="education" class="section-anchor"></a>', unsafe_allow_html
 # --- Spacer before next section ---
 st.markdown(
     """
-    <div class="card hover-zoom">
+    <div class="card hover-zoom" data-portfolio-section="education">
       <div class="section-title" style="background:#34495E;">Education</div>
       <div class="edu-cards-grid">
         <div class="edu-card">
@@ -955,7 +955,7 @@ st.markdown(
 st.markdown('<a name="experience" class="section-anchor"></a>', unsafe_allow_html=True)
 st.markdown(
     """  
-    <div class="card hover-zoom">
+    <div class="card hover-zoom" data-portfolio-section="experience">
       <div class="section-title" style="background:#34495E;">Professional Experience</div>
       <div class="exp-cards-grid">
         <div class="exp-card">
@@ -1017,7 +1017,7 @@ st.markdown(
 st.markdown('<a name="certifications" class="section-anchor"></a>', unsafe_allow_html=True)
 st.markdown(
     """
-    <div class="card hover-zoom">
+    <div class="card hover-zoom" data-portfolio-section="certifications">
       <div class="section-title" style="background:#34495E;">Certifications & Courses</div>
       <div class="cert-grid">
         <div class="cert-card">
@@ -1055,7 +1055,7 @@ st.markdown(
 st.markdown('<a name="recognitions" class="section-anchor"></a>', unsafe_allow_html=True)
 st.markdown(
     """
-    <div class="card hover-zoom">
+    <div class="card hover-zoom" data-portfolio-section="recognitions">
       <div class="section-title" style="background:#34495E;">Awards & Recognitions</div>
       <div class="awards-grid">
         <div class="award-card">
@@ -1254,7 +1254,7 @@ st.markdown("""
 """, unsafe_allow_html=True)
 
 projects_html = '''
-<div class="card projects-gallery-pane hover-zoom">
+<div class="card projects-gallery-pane hover-zoom" data-portfolio-section="projects">
   <div class="section-title">Featured Projects</div>
   <div class="projects-4col-grid">
 '''
@@ -1357,7 +1357,7 @@ st.markdown("""
 </style>
 
 
-<div class="skills-section hover-zoom">
+<div class="skills-section hover-zoom" data-portfolio-section="skills">
   <div class="skills-header-title">Core Skills and Tools</div>
   <div class="skill-grid">
 <div class="skill-card">

--- a/streamlit_app_single_pane.py
+++ b/streamlit_app_single_pane.py
@@ -863,7 +863,7 @@ st.markdown("""
 }
 </style>
 
-<div class="hero-card">
+<div class="hero-card" data-portfolio-section="about">
   <div class="hero-left">
     <div class="hero-pic-glow">
       <img src="https://raw.githubusercontent.com/venkateshsoundar/venkatesh_portfolio/main/Venkatesh_Profile_2026.jpg" alt="Venkatesh Soundararajan"/>
@@ -907,7 +907,7 @@ st.markdown('<a name="education" class="section-anchor"></a>', unsafe_allow_html
 # --- Spacer before next section ---
 st.markdown(
     """
-    <div class="card hover-zoom">
+    <div class="card hover-zoom" data-portfolio-section="education">
       <div class="section-title" style="background:#34495E;">Education</div>
       <div class="edu-cards-grid">
         <div class="edu-card">
@@ -938,7 +938,7 @@ st.markdown(
 st.markdown('<a name="experience" class="section-anchor"></a>', unsafe_allow_html=True)
 st.markdown(
     """  
-    <div class="card hover-zoom">
+    <div class="card hover-zoom" data-portfolio-section="experience">
       <div class="section-title" style="background:#34495E;">Professional Experience</div>
       <div class="exp-cards-grid">
         <div class="exp-card">
@@ -1000,7 +1000,7 @@ st.markdown(
 st.markdown('<a name="certifications" class="section-anchor"></a>', unsafe_allow_html=True)
 st.markdown(
     """
-    <div class="card hover-zoom">
+    <div class="card hover-zoom" data-portfolio-section="certifications">
       <div class="section-title" style="background:#34495E;">Certifications & Courses</div>
       <div class="cert-grid">
         <div class="cert-card">
@@ -1038,7 +1038,7 @@ st.markdown(
 st.markdown('<a name="recognitions" class="section-anchor"></a>', unsafe_allow_html=True)
 st.markdown(
     """
-    <div class="card hover-zoom">
+    <div class="card hover-zoom" data-portfolio-section="recognitions">
       <div class="section-title" style="background:#34495E;">Awards & Recognitions</div>
       <div class="awards-grid">
         <div class="award-card">
@@ -1237,7 +1237,7 @@ st.markdown("""
 """, unsafe_allow_html=True)
 
 projects_html = '''
-<div class="card projects-gallery-pane hover-zoom">
+<div class="card projects-gallery-pane hover-zoom" data-portfolio-section="projects">
   <div class="section-title">Featured Projects</div>
   <div class="projects-4col-grid">
 '''
@@ -1340,7 +1340,7 @@ st.markdown("""
 </style>
 
 
-<div class="skills-section hover-zoom">
+<div class="skills-section hover-zoom" data-portfolio-section="skills">
   <div class="skills-header-title">Core Skills and Tools</div>
   <div class="skill-grid">
 <div class="skill-card">


### PR DESCRIPTION
## Summary
- tag all seven portfolio sections with stable identifiers in both Streamlit entry points
- build each slide from its own Streamlit element container instead of assuming every section shares one direct parent
- hide original section and anchor containers individually while keeping arrows, swipe, menu navigation, dots, and pop animations

## Root cause
The merged carousel initializer required every section wrapper to have the same parent. Streamlit's live DOM adds wrapper layers, so that check failed and the carousel silently never initialized.

## Validation
- Python syntax compilation passed
- JavaScript syntax check passed
- Streamlit AppTest completed with 0 exceptions
- DOM regression test created all 7 slides and 7 dots with deliberately different wrapper parents
- DOM regression test verified next-arrow and navbar-to-slide navigation
- `git diff --check` passed