### PR TITLE
Restore full project gallery and menu spacing

### DIFF
--- a/portfolio_carousel.py
+++ b/portfolio_carousel.py
@@ -44,10 +44,13 @@ def render_section_carousel():
     }
     div[data-testid="stElementContainer"].portfolio-page-container-active {
       box-sizing: border-box;
-      padding-top: 30px !important;
+      padding-top: 0 !important;
+      padding-bottom: 30px !important;
     }
     [data-portfolio-section].portfolio-page-active {
       animation: portfolio-page-pop 0.52s cubic-bezier(0.22, 0.82, 0.32, 1);
+      position: relative;
+      top: 30px;
       transform-origin: center top;
     }
     .navbar a {
@@ -140,7 +143,10 @@ def render_section_carousel():
     }
     @media (max-width: 700px) {
       div[data-testid="stElementContainer"].portfolio-page-container-active {
-        padding-top: 20px !important;
+        padding-bottom: 20px !important;
+      }
+      [data-portfolio-section].portfolio-page-active {
+        top: 20px;
       }
       .navbar a::before {
         display: none;

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -649,6 +649,34 @@ projects = [
         "desc": "Analyzed neighborhood-level crime patterns to identify key drivers and communicate actionable urban insights."
     },
     {
+        "title": "Weight Change Regression Analysis",
+        "url": "https://github.com/venkateshsoundar/weight-change-regression-analysis",
+        "image": "https://raw.githubusercontent.com/venkateshsoundar/venkatesh_portfolio/main/Weight_Change.jpeg",
+        "tools": ["Python", "Scikit-learn", "Seaborn"],
+        "desc": "Built regression models to predict weight changes based on lifestyle and demographic data."
+    },
+    {
+        "title": "Calgary Childcare Compliance",
+        "url": "https://github.com/venkateshsoundar/calgary-childcare-compliance",
+        "image": "https://raw.githubusercontent.com/venkateshsoundar/venkatesh_portfolio/main/CalgaryChildcare.jpeg",
+        "tools": ["Python", "Pandas", "Plotly"],
+        "desc": "Assessed childcare center compliance in Calgary through data-driven dashboards."
+    },
+    {
+        "title": "Social Media Purchase Influence",
+        "url": "https://github.com/venkateshsoundar/social-media-purchase-influence",
+        "image": "https://raw.githubusercontent.com/venkateshsoundar/venkatesh_portfolio/main/ConsumerPurchaseDecision.jpeg",
+        "tools": ["Python", "Scikit-learn", "Power BI"],
+        "desc": "Modeled and visualized the impact of social media on consumer purchase behavior."
+    },
+    {
+        "title": "Obesity Level Estimation",
+        "url": "https://github.com/venkateshsoundar/obesity-level-estimation",
+        "image": "https://raw.githubusercontent.com/venkateshsoundar/venkatesh_portfolio/main/ObeseLevels.jpeg",
+        "tools": ["Python", "Logistic Regression", "Pandas"],
+        "desc": "Predicted obesity levels from health and lifestyle features using classification algorithms."
+    },
+    {
         "title": "Alberta Wildfire Analysis",
         "url": "https://github.com/venkateshsoundar/alberta-wildfire-analysis",
         "image": "https://raw.githubusercontent.com/venkateshsoundar/venkatesh_portfolio/main/Alberta_forestfire.jpeg",
@@ -668,6 +696,13 @@ projects = [
         "image": "https://raw.githubusercontent.com/venkateshsoundar/venkatesh_portfolio/main/Penguin_Analysis.jpeg",
         "tools": ["Python", "Scikit-learn", "Streamlit"],
         "desc": "Developed an interactive machine-learning application that predicts penguin species from user inputs."
+    },
+    {
+        "title": "Uber Ride Prediction",
+        "url": "https://github.com/venkateshsoundar/uber-ride-duration-predictorapp",
+        "image": "https://raw.githubusercontent.com/venkateshsoundar/venkatesh_portfolio/main/Uberride_Prediction.jpeg",
+        "tools": ["Python", "XGBoost", "Matplotlib"],
+        "desc": "Predicted Uber ride durations using machine learning and explained predictions with visualizations."
     }
 ]
 

--- a/streamlit_app_single_pane.py
+++ b/streamlit_app_single_pane.py
@@ -632,6 +632,34 @@ projects = [
         "desc": "Analyzed neighborhood-level crime patterns to identify key drivers and communicate actionable urban insights."
     },
     {
+        "title": "Weight Change Regression Analysis",
+        "url": "https://github.com/venkateshsoundar/weight-change-regression-analysis",
+        "image": "https://raw.githubusercontent.com/venkateshsoundar/venkatesh_portfolio/main/Weight_Change.jpeg",
+        "tools": ["Python", "Scikit-learn", "Seaborn"],
+        "desc": "Built regression models to predict weight changes based on lifestyle and demographic data."
+    },
+    {
+        "title": "Calgary Childcare Compliance",
+        "url": "https://github.com/venkateshsoundar/calgary-childcare-compliance",
+        "image": "https://raw.githubusercontent.com/venkateshsoundar/venkatesh_portfolio/main/CalgaryChildcare.jpeg",
+        "tools": ["Python", "Pandas", "Plotly"],
+        "desc": "Assessed childcare center compliance in Calgary through data-driven dashboards."
+    },
+    {
+        "title": "Social Media Purchase Influence",
+        "url": "https://github.com/venkateshsoundar/social-media-purchase-influence",
+        "image": "https://raw.githubusercontent.com/venkateshsoundar/venkatesh_portfolio/main/ConsumerPurchaseDecision.jpeg",
+        "tools": ["Python", "Scikit-learn", "Power BI"],
+        "desc": "Modeled and visualized the impact of social media on consumer purchase behavior."
+    },
+    {
+        "title": "Obesity Level Estimation",
+        "url": "https://github.com/venkateshsoundar/obesity-level-estimation",
+        "image": "https://raw.githubusercontent.com/venkateshsoundar/venkatesh_portfolio/main/ObeseLevels.jpeg",
+        "tools": ["Python", "Logistic Regression", "Pandas"],
+        "desc": "Predicted obesity levels from health and lifestyle features using classification algorithms."
+    },
+    {
         "title": "Alberta Wildfire Analysis",
         "url": "https://github.com/venkateshsoundar/alberta-wildfire-analysis",
         "image": "https://raw.githubusercontent.com/venkateshsoundar/venkatesh_portfolio/main/Alberta_forestfire.jpeg",
@@ -651,6 +679,13 @@ projects = [
         "image": "https://raw.githubusercontent.com/venkateshsoundar/venkatesh_portfolio/main/Penguin_Analysis.jpeg",
         "tools": ["Python", "Scikit-learn", "Streamlit"],
         "desc": "Developed an interactive machine-learning application that predicts penguin species from user inputs."
+    },
+    {
+        "title": "Uber Ride Prediction",
+        "url": "https://github.com/venkateshsoundar/uber-ride-duration-predictorapp",
+        "image": "https://raw.githubusercontent.com/venkateshsoundar/venkatesh_portfolio/main/Uberride_Prediction.jpeg",
+        "tools": ["Python", "XGBoost", "Matplotlib"],
+        "desc": "Predicted Uber ride durations using machine learning and explained predictions with visualizations."
     }
 ]
 


### PR DESCRIPTION
## What changed

- restores the five missing gallery entries: Weight Change Regression Analysis, Calgary Childcare Compliance, Social Media Purchase Influence, Obesity Level Estimation, and Uber Ride Prediction
- brings the gallery back to all 11 portfolio projects in both Streamlit entry points
- replaces collapsible top padding with a reliable 30px section offset on desktop and 20px on mobile
- reserves matching bottom space so the moved card does not overlap following content
- preserves circular paging, dotted navigation, menu progress, drag/swipe, keyboard navigation, and animations

## Root cause

The project data list had been reduced from 11 entries to 6. Separately, Streamlit could collapse the container padding used for menu clearance, allowing the Projects card to sit directly beneath the sticky menu.

## Validation

- verified exactly 11 project records in both Streamlit entry files
- verified all five restored project titles
- Streamlit single-pane render produced 11 project cards with zero exceptions
- JavaScript and Python syntax checks passed
- circular pager DOM integration test passed