### PR TITLE
Reset page scroll on section navigation

### DIFF
--- a/portfolio_carousel.py
+++ b/portfolio_carousel.py
@@ -314,6 +314,47 @@ def render_section_carousel():
       });
     }
 
+    function resetPageScroll() {
+      const scrollTargets = new Set([
+        pageDocument.scrollingElement,
+        pageDocument.documentElement,
+        pageDocument.body,
+        pageDocument.querySelector('[data-testid="stAppViewContainer"]'),
+        pageDocument.querySelector('[data-testid="stMain"]'),
+        pageDocument.querySelector(".stAppViewContainer"),
+        pageDocument.querySelector(".main")
+      ]);
+
+      let ancestor = sourceContainers[activeIndex]?.parentElement;
+      while (ancestor && ancestor !== pageDocument.body) {
+        const overflowY = window.getComputedStyle(ancestor).overflowY;
+        if (
+          ["auto", "scroll", "overlay"].includes(overflowY) ||
+          ancestor.scrollHeight > ancestor.clientHeight
+        ) {
+          scrollTargets.add(ancestor);
+        }
+        ancestor = ancestor.parentElement;
+      }
+
+      const moveToTop = () => {
+        scrollTargets.forEach((target) => {
+          if (!target) {
+            return;
+          }
+          if (typeof target.scrollTo === "function") {
+            target.scrollTo({ top: 0, left: 0, behavior: "auto" });
+          }
+          target.scrollTop = 0;
+          target.scrollLeft = 0;
+        });
+        window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+      };
+
+      moveToTop();
+      window.requestAnimationFrame(moveToTop);
+    }
+
     function activate(index, options = {}) {
       const {
         scroll = true,
@@ -353,12 +394,7 @@ def render_section_carousel():
         window.history.replaceState(null, "", `#${sectionIds[activeIndex]}`);
       }
       if (scroll) {
-        sectionRoots[activeIndex].scrollIntoView({
-          behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches
-            ? "auto"
-            : "smooth",
-          block: "start"
-        });
+        resetPageScroll();
       }
     }
 


### PR DESCRIPTION
## What changed

- resets the Streamlit scroll container to the top whenever users change sections
- applies to menu clicks, dots, keyboard navigation, swipe, drag, and hash navigation
- resets both Streamlit-specific scroll containers and the browser document as a fallback
- repeats the reset on the next animation frame after the new card is displayed
- removes the previous `scrollIntoView()` behavior that could align a card beneath the sticky menu

## Why

When a visitor navigated away from a long page such as Projects, the next section inherited an unfavorable scroll position. `scrollIntoView()` could then place the new card directly beneath the sticky menu and hide the intended gap.

## Validation

- DOM integration test verifies that navigation triggers a top reset
- confirmed `scrollIntoView()` is no longer present
- JavaScript and Python syntax checks passed
- Streamlit single-pane render completed with zero exceptions
- existing circular navigation, dots, menu progress, gestures, and animation tests remain passing