### PR TITLE
Use dot-only navigation on mobile

### DIFF
--- a/portfolio_carousel.py
+++ b/portfolio_carousel.py
@@ -256,7 +256,17 @@ def render_section_carousel():
         transform: scale(1);
       }
     }
-    @media (max-width: 700px) {
+    @media (max-width: 768px) {
+      .navbar-container {
+        min-height: 0 !important;
+        padding: 0 !important;
+        border-radius: 0 0 14px 14px !important;
+        justify-content: center !important;
+      }
+      .navbar,
+      .mobile-nav-toggle {
+        display: none !important;
+      }
       div[data-testid="stElementContainer"].portfolio-page-container-active {
         padding-bottom: 20px !important;
       }
@@ -267,7 +277,19 @@ def render_section_carousel():
         display: none;
       }
       .portfolio-pager-dots {
-        padding-bottom: 8px;
+        display: flex !important;
+        min-height: 38px;
+        margin: 0;
+        padding: 10px 14px 11px;
+        background: rgba(15, 31, 61, 0.72);
+        backdrop-filter: blur(10px);
+      }
+      .portfolio-pager-dot {
+        width: 9px;
+        height: 9px;
+      }
+      .portfolio-pager-dot.is-active {
+        width: 28px;
       }
     }
     @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## What changed

- hides the full section-link menu on screens up to 768px wide
- hides the mobile hamburger/menu button
- keeps a compact sticky row of seven clickable navigation dots at the top
- slightly enlarges mobile dots for touch visibility while retaining the gold active indicator
- preserves swipe navigation, circular paging, scroll reset, animation, and desktop navigation

## Why

The full text menu is too large for mobile, while a compact dotted indicator communicates that multiple pages are available without consuming significant screen space.

## Validation

- verified mobile CSS hides both menu links and the toggle
- verified dotted navigation remains displayed and touch-sized
- DOM navigation integration test passed
- JavaScript and Python syntax checks passed
- Streamlit single-pane render completed with zero exceptions