### PR TITLE
Fix mobile navigation spacing

### DIFF
--- a/portfolio_carousel.py
+++ b/portfolio_carousel.py
@@ -274,10 +274,11 @@ def render_section_carousel():
         display: none !important;
       }
       div[data-testid="stElementContainer"].portfolio-page-container-active {
+        padding-top: calc(60px + env(safe-area-inset-top)) !important;
         padding-bottom: 20px !important;
       }
       [data-portfolio-section].portfolio-page-active {
-        top: 20px;
+        top: 0;
       }
       .navbar a::before {
         display: none;


### PR DESCRIPTION
## What changed
- Reserved the fixed mobile navigation height above every active section
- Added a consistent 16px visual gap between the mobile navigation bar and the section card
- Replaced relative card shifting with container padding so the space participates in layout
- Left desktop spacing unchanged

## Root cause
The mobile dotted navigation is fixed to the viewport and the original navbar placeholder is hidden on small screens. The section card therefore began underneath the fixed bar.

## Validation
- Python syntax compilation passed
- Embedded JavaScript syntax check passed
- Portfolio pager DOM interaction test passed
- Mobile spacing assertions passed
- Streamlit smoke test passed