### PR TITLE
Remove mobile section name

### DIFF
--- a/portfolio_carousel.py
+++ b/portfolio_carousel.py
@@ -120,9 +120,6 @@ def render_section_carousel():
       gap: 8px;
       padding: 0 16px 9px;
     }
-    .portfolio-pager-mobile-label {
-      display: none;
-    }
     .portfolio-pager-dot {
       width: 8px;
       height: 8px;
@@ -306,21 +303,6 @@ def render_section_carousel():
         backdrop-filter: blur(10px);
         pointer-events: auto !important;
       }
-      .portfolio-pager-mobile-label {
-        display: inline-flex;
-        align-items: center;
-        justify-content: flex-end;
-        width: 120px;
-        max-width: 120px;
-        margin-right: 2px;
-        overflow: hidden;
-        color: var(--portfolio-gold);
-        font-size: 0.8rem;
-        font-weight: 800;
-        line-height: 1;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
       .portfolio-pager-dot {
         width: 9px;
         height: 9px;
@@ -444,11 +426,6 @@ def render_section_carousel():
       navbarLinks.find((link) => link.getAttribute("href") === `#${id}`)
         ?.textContent?.trim() || id
     );
-    const mobilePageLabel = pageDocument.createElement("span");
-    mobilePageLabel.className = "portfolio-pager-mobile-label";
-    mobilePageLabel.setAttribute("aria-live", "polite");
-    dotNavigation.appendChild(mobilePageLabel);
-
     const dotButtons = sectionIds.map((id, index) => {
       const dot = pageDocument.createElement("button");
       const sectionName = sectionNames[index];
@@ -501,7 +478,6 @@ def render_section_carousel():
     }
 
     function updateDots() {
-      mobilePageLabel.textContent = sectionNames[activeIndex];
       dotButtons.forEach((dot, dotIndex) => {
         const isActive = dotIndex === activeIndex;
         dot.classList.toggle("is-active", isActive);


### PR DESCRIPTION
## What changed
- Removed the visible current-section name from the mobile navigation bar
- Kept the seven navigation dots centered and available on mobile
- Preserved the fixed-bar spacing, circular paging, swipe lock, and desktop navigation
- Retained accessible labels and tooltips on the dot buttons

## Validation
- Python syntax compilation passed
- Embedded JavaScript syntax check passed
- Dot-only mobile navigation assertions passed
- Portfolio pager DOM interaction test passed
- Streamlit smoke test passed